### PR TITLE
lsm6dsv_reg.c(h): Fix enum values names

### DIFF
--- a/lsm6dsv_reg.c
+++ b/lsm6dsv_reg.c
@@ -2404,16 +2404,16 @@ int32_t lsm6dsv_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv_den_conf_t *val)
 
   switch ((den.lvl1_en << 1) + den.lvl2_en)
   {
-    case LEVEL_TRIGGER:
-      val->mode = LEVEL_TRIGGER;
+    case LSM6DSV_LEVEL_TRIGGER:
+      val->mode = LSM6DSV_LEVEL_TRIGGER;
       break;
 
-    case LEVEL_LATCHED:
-      val->mode = LEVEL_LATCHED;
+    case LSM6DSV_LEVEL_LATCHED:
+      val->mode = LSM6DSV_LEVEL_LATCHED;
       break;
 
     default:
-      val->mode = DEN_NOT_DEFINED;
+      val->mode = LSM6DSV_DEN_NOT_DEFINED;
       break;
   }
 

--- a/lsm6dsv_reg.h
+++ b/lsm6dsv_reg.h
@@ -3876,9 +3876,9 @@ typedef struct
   uint8_t den_z                : 1;
   enum
   {
-    DEN_NOT_DEFINED = 0x00,
-    LEVEL_TRIGGER   = 0x02,
-    LEVEL_LATCHED   = 0x03,
+    LSM6DSV_DEN_NOT_DEFINED = 0x00,
+    LSM6DSV_LEVEL_TRIGGER   = 0x02,
+    LSM6DSV_LEVEL_LATCHED   = 0x03,
   } mode;
 } lsm6dsv_den_conf_t;
 int32_t lsm6dsv_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv_den_conf_t val);


### PR DESCRIPTION
Names of some of the enum values changed to avoid value names collision when used along with LSM6DSV32X sensors in the same project